### PR TITLE
Add graphviz to an image of ruby2.6.2-node10.18.1

### DIFF
--- a/circleci/ruby/2.6.2/Dockerfile.node-10.18.1
+++ b/circleci/ruby/2.6.2/Dockerfile.node-10.18.1
@@ -39,7 +39,8 @@ RUN yum update -y && \
     yum install -y git gcc gcc-c++ openssl openssl-devel readline readline-devel \
     mysql mysql-devel bzip2 postgresql postgresql-devel sudo tar libXi libX11 \
     libXcomposite libXcursor libXdamage libXext libXtst libXi.so.6 cups-libs \
-    libXScrnSaver libdrm libXrandr libgbm alsa-lib atk at-spi2-atk pango gtk3
+    libXScrnSaver libdrm libXrandr libgbm alsa-lib atk at-spi2-atk pango gtk3 \
+    graphviz
 
 ###########################################################################
 # Ruby:


### PR DESCRIPTION
[レビュー観点]( https://github.com/f-scratch/zelda-docs/blob/master/3.Rules/4.Review/3.SourceReview.md "レビュー観点")

## Redmineチケット

なし

## やったこと

zelda-scoringのciで利用しているdocker imageに対してgraphvizをインストール

## やっていないこと

特になし

## スクリーンショット

無し

## 影響範囲調査結果

スコアリングのCI（通ったことは確認済み）