### PR TITLE
add: unixODBC-devel.x86_64

### DIFF
--- a/circleci/ruby/2.7.1/Dockerfile.amazonlinux2
+++ b/circleci/ruby/2.7.1/Dockerfile.amazonlinux2
@@ -36,7 +36,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ###########################################################################
 
 RUN yum update -y && \
-    yum install -y git gcc gcc-c++ openssl openssl-devel readline readline-devel mysql mysql-devel bzip2 postgresql postgresql-devel sudo tar libiodbc unixODBC.x86_64
+    yum install -y git gcc gcc-c++ openssl openssl-devel readline readline-devel mysql mysql-devel bzip2 postgresql postgresql-devel sudo tar libiodbc unixODBC.x86_64 unixODBC-devel.x86_64
 
 ###########################################################################
 # Ruby:


### PR DESCRIPTION
## やったこと
ruby-odbc入りで `bundle install` できなかったので `unixODBC-devel.x86_64` を追加