### PR TITLE
add java/11.0.5/Dockerfile

### DIFF
--- a/circleci/java/11.0.5/Dockerfile
+++ b/circleci/java/11.0.5/Dockerfile
@@ -1,0 +1,64 @@
+###########################################################################
+##
+##--------------------------------------------------------------------------
+## Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/java/tags/
+#
+# Note: Base Image name format fromscratch/java:{java-version}u{java-update}
+#
+###########################################################################
+
+FROM frolvlad/alpine-glibc:alpine-3.11
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# variables:
+###########################################################################
+
+ENV JAVA_HOME="/usr/lib/jvm/default-jvm" \
+    MYSQL_CONNECTOR_JAVA_VERSION=5.1.40
+
+###########################################################################
+# jdk:
+###########################################################################
+
+RUN apk add openjdk11
+
+###########################################################################
+## set PATH:
+############################################################################
+
+ENV PATH=$PATH:$JAVA_HOME/bin
+
+###########################################################################
+# python and awscli and curl:
+###########################################################################
+
+RUN apk update --no-cache && \
+    apk add --no-cache --virtual=build-dependencies python py-pip py-setuptools ca-certificates && \
+    pip install --no-cache-dir awscli && \
+    apk del build-dependencies && \
+    apk add --no-cache python curl && \
+    rm -rf /var/cache/apk/*
+
+###########################################################################
+# add user 'circleci':
+# cf. circleci/ruby:2.3.1-node
+# https://hub.docker.com/r/circleci/ruby/tags/
+# maven for executing maven
+###########################################################################
+
+RUN apk add --no-cache bash git openssh tar gzip sudo wget maven && \
+  addgroup -g 3434 circleci && \
+  adduser -D -u 3434 -G circleci -s /bin/bash circleci && \
+  echo 'circleci ALL=NOPASSWD: ALL' > /etc/sudoers
+
+USER circleci
+
+WORKDIR /target
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
[レビュー観点]( https://github.com/f-scratch/zelda-docs/blob/master/3.Rules/4.Review/3.SourceReview.md "レビュー観点")

## Redmineチケット
none 


## やったこと
java11用のDockerfileを追加


## やっていないこと
none


## スクリーンショット

### before
none


### after
none


## 影響範囲調査結果
docker-hubにdocker imageをpush済
https://hub.docker.com/layers/fromscratch/java/11.0.5-alpine/images/sha256-2688ca4ef2a4bac9e640107f3249a47a3167043c2650fbb71371b2f16b58a0f3?context=explore

ローカルで立ち上げたdockerコンテナのjavaのバージョンが11であることを確認
```
bash-5.0$ java -version
openjdk version "11.0.5" 2019-10-15
OpenJDK Runtime Environment (build 11.0.5+10-alpine-r0)
OpenJDK 64-Bit Server VM (build 11.0.5+10-alpine-r0, mixed mode)
```