### PR TITLE
add ruby/2.7.1/amazonlinux2.imagemagic-6.9.10-97

### DIFF
--- a/circleci/ruby/2.7.1/Dockerfile.amazonlinux2.imagemagic-6.9.10-97
+++ b/circleci/ruby/2.7.1/Dockerfile.amazonlinux2.imagemagic-6.9.10-97
@@ -1,0 +1,116 @@
+###########################################################################
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/ruby/tags/
+#
+# Note: Base Image name format fromscratch/ruby:{ruby-version}-amazonlinux{amazonlinux-version}-{ami-version}
+#
+###########################################################################
+
+FROM amazonlinux:2.0.20200722.0
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# Versions:
+###########################################################################
+
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.1
+ENV NODE_VERSION 12.18.0
+ENV YARN_VERSION 1.22.5
+ENV IMAGEMAGICK_VERSION 6.9.10-97
+
+###########################################################################
+# Set Timezone
+###########################################################################
+
+ENV TZ Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+###########################################################################
+# Common:
+###########################################################################
+
+RUN yum update -y && \
+    yum install -y git gcc gcc-c++ openssl openssl-devel readline readline-devel mysql mysql-devel bzip2 postgresql postgresql-devel sudo tar libiodbc unixODBC.x86_64 unixODBC-devel.x86_64
+
+###########################################################################
+# Ruby:
+###########################################################################
+
+RUN mkdir -p /build/ruby && \
+    curl -s https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz | tar -C /build/ruby -xzf - && \
+    cd /build/ruby/ruby-$RUBY_VERSION && \
+    ./configure --disable-install-doc && \
+    make && make install && \
+    gem install bundler && \
+    rm -fr /build/ruby
+
+###########################################################################
+# node:
+###########################################################################
+
+ENV NVM_DIR /root/.nvm
+
+RUN echo $HOME && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash && \
+    . $NVM_DIR/nvm.sh && \
+    nvm install ${NODE_VERSION} && \
+    nvm use ${NODE_VERSION} && \
+    nvm alias ${NODE_VERSION} && \
+    npm install eslint --save-dev && \
+    echo "" >> ~/.bashrc && \
+    echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
+
+###########################################################################
+# YARN:
+###########################################################################
+
+RUN [ -s "$NVM_DIR/nvm.sh" ] && \
+    . $NVM_DIR/nvm.sh && \
+    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION} && \
+    echo "" >> ~/.bashrc && \
+    echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> ~/.bashrc
+
+###########################################################################
+# awscli and socat:
+###########################################################################
+
+RUN yum install -y python3 python3-devel && \
+    pip3 install --upgrade pip && \
+    pip install --upgrade setuptools && \
+    pip install awscli
+
+###########################################################################
+## ImageMagick@6:
+############################################################################
+
+RUN mkdir -p /build/imagemagick && \
+    cd /build/imagemagick && \
+    yum install -y tar xz && \
+    curl -O https://download.imagemagick.org/ImageMagick/download/releases/ImageMagick-$IMAGEMAGICK_VERSION.tar.xz && \
+    xz -dv ImageMagick-$IMAGEMAGICK_VERSION.tar.xz && \
+    tar xfv ImageMagick-$IMAGEMAGICK_VERSION.tar && \
+    cd /build/imagemagick/ImageMagick-$IMAGEMAGICK_VERSION && \
+    ./configure && \
+    make && make install && \
+    yum install -y libjpeg-devel libpng-devel ImageMagick-devel && \
+    rm -fr /build/imagemagick && \
+    yum clean all
+
+###########################################################################
+# update sudoers
+###########################################################################
+
+RUN sed -i "/secure_path/c\Defaults    secure_path = $PATH" /etc/sudoers
+
+WORKDIR /target
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
[レビュー観点]( https://github.com/f-scratch/zelda-docs/blob/master/3.Rules/4.Review/3.SourceReview.md "レビュー観点")

## Redmineチケット

none

## やったこと

- b→dash4.0のzelda-action4thにてCircleCiのコンテナにImagemagicがインストールされてないとbundle installが通らないため、Imagemagicがインストールされたamazonlinux2のコンテナを作成した。
```
An error occurred while installing rmagick (3.2.0), and Bundler cannot
```

## やっていないこと

none

## スクリーンショット

### before

none

### after

none

## 影響範囲調査結果
Docker hubにアップ済
![image](https://user-images.githubusercontent.com/46437943/132803042-6c11a4c4-d71a-45e7-8a3d-03c5d5d8cb6e.png)
