### PR TITLE
[DEV018840] add: tidb image

### DIFF
--- a/circleci/tiup/Dockerfile
+++ b/circleci/tiup/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:latest
+
+ENV TZ UTC
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+  && apt-get -y install curl tzdata \
+  && dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh -O && sh install.sh \
+    && /root/.tiup/bin/tiup install playground pd tikv tiup grafana tiflash prometheus
+
+ENV PATH="/root/.tiup/bin:${PATH}"
+
+EXPOSE 2379 3000 4000 9090 10080
+
+CMD ["/root/.tiup/bin/tiup", "playground", "--host", "0.0.0.0", "--db", "1", "--kv", "1", "--pd", "1", "--tiflash", "1"]


### PR DESCRIPTION
## やったこと
- circleciで使うためのtidbのイメージを追加

- m1 macでarm64になるので、buildxを使ってマルチプラットフォームでビルドできるようにする
```zsh
docker buildx create --name multi-platform-builder --use
docker buildx inspect --bootstrap
```
- マルチプラットフォームでビルド& push
```zsh
docker buildx build --platform linux/amd64,linux/arm64 -t fromscratch/tiup-playground:latest --push .
```
- pushできた
https://hub.docker.com/repository/docker/fromscratch/tiup-playground/tags?page=1&ordering=last_updated
<img width="1395" alt="image" src="https://github.com/f-scratch/fs-dockerfiles/assets/22384589/aa66dec1-d459-4478-9db8-e07832630d73">

- このイメージを使ってCIでrspecを通せた
https://app.circleci.com/pipelines/github/f-scratch/ness-billing4th/968/workflows/a7b9f2f7-5990-49cf-81dd-730ebc6ce77c/jobs/5170
![image](https://github.com/f-scratch/fs-dockerfiles/assets/22384589/0c89a94c-b9e7-4a51-b1db-b9989220070d)
