### PR TITLE
[chore0418] add ruby 2.7.2

### DIFF
--- a/circleci/ruby/2.7.2/Dockerfile.node-14.18.0
+++ b/circleci/ruby/2.7.2/Dockerfile.node-14.18.0
@@ -1,0 +1,126 @@
+###########################################################################
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/ruby/tags/
+#
+# Note: Base Image name format fromscratch/ruby:{ruby-version}-node-{node-version}
+#
+###########################################################################
+
+FROM ruby:2.7.2
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# variables:
+###########################################################################
+
+ENV NODE_VERSION 14.18.0
+ENV YARN_VERSION 1.22.19
+ENV RUBYOPT=-EUTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HUB_VER 2.13.0
+ENV HUB_ARCH_TYPE linux-amd64
+
+###########################################################################
+# node:
+###########################################################################
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    4ED778F539E3634C779C87C6D7062848A1AB005C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+###########################################################################
+# yarn:
+###########################################################################
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+###########################################################################
+# awscli and socat:
+###########################################################################
+
+RUN apt-get update \
+  && apt-get install -y python python-dev python-pip python-setuptools groff less socat sudo locales graphviz default-mysql-client unixodbc-dev \
+  && pip install --upgrade awscli \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+###########################################################################
+# hub command:
+###########################################################################
+
+RUN wget https://github.com/github/hub/releases/download/v$HUB_VER/hub-$HUB_ARCH_TYPE-$HUB_VER.tgz \
+  && tar zvxvf hub-$HUB_ARCH_TYPE-$HUB_VER.tgz \
+  && ./hub-$HUB_ARCH_TYPE-$HUB_VER/install \
+  && rm -rf hub-$HUB_ARCH_TYPE-$HUB_VER
+
+###########################################################################
+# add user 'circleci':
+# cf. circleci/ruby:2.3.1-node
+# https://hub.docker.com/r/circleci/ruby/tags/
+###########################################################################
+
+RUN groupadd --gid 3434 circleci \
+  && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \
+  && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \
+  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+
+USER circleci
+
+WORKDIR /target
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
## やったこと
ruby2.7.2のDockerfile作成

- buildできた
```
 % docker build -t test:1 -f Dockerfile.node-14.18.0 .
[+] Building 3.0s (13/13) FINISHED  
```

- 指定のバージョンがインストールされている
```
$ node -v
v14.18.0
$ yarn -v
1.22.19
$ ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
```

- ビルド& push
```
docker build --platform linux/amd64 -t fromscratch/ruby:2.7.2-node-14.18.0 -f Dockerfile.node-14.18.0 --push .
```

- pushできた
https://hub.docker.com/layers/fromscratch/ruby/2.7.2-node-14.18.0/images/sha256-034d41a1e3402edd0aebfa7b382ddbb8cf2099ab11050d8eb4d4f53e63b3f1a7?context=repo
![スクリーンショット 2023-11-30 18 20 58](https://github.com/f-scratch/fs-dockerfiles/assets/124575694/41bd4941-a7b1-4138-9574-e4b9a0d14875)
