### PR TITLE
[CHORE0558] add docker images ruby/2.7.1/Dockerfile.node-14.21.3

### DIFF
--- a/circleci/ruby/2.7.1/Dockerfile.node-14.21.3
+++ b/circleci/ruby/2.7.1/Dockerfile.node-14.21.3
@@ -1,0 +1,126 @@
+###########################################################################
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/ruby/tags/
+#
+# Note: Base Image name format fromscratch/ruby:{ruby-version}-node-{node-version}
+#
+###########################################################################
+
+FROM ruby:2.7.1
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# variables:
+###########################################################################
+
+ENV NODE_VERSION 14.21.3
+ENV YARN_VERSION 1.22.4
+ENV RUBYOPT=-EUTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HUB_VER 2.13.0
+ENV HUB_ARCH_TYPE linux-amd64
+
+###########################################################################
+# node:
+###########################################################################
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
+
+RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+  && case "${dpkgArch##*-}" in \
+    amd64) ARCH='x64';; \
+    ppc64el) ARCH='ppc64le';; \
+    s390x) ARCH='s390x';; \
+    arm64) ARCH='arm64';; \
+    armhf) ARCH='armv7l';; \
+    i386) ARCH='x86';; \
+    *) echo "unsupported architecture"; exit 1 ;; \
+  esac \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+###########################################################################
+# yarn:
+###########################################################################
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+
+###########################################################################
+# awscli and socat:
+###########################################################################
+
+RUN apt-get update \
+  && apt-get install -y python python-dev python-pip python-setuptools groff less socat sudo locales graphviz default-mysql-client unixodbc-dev \
+  && pip install --upgrade awscli \
+  && apt-get clean \
+  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+###########################################################################
+# hub command:
+###########################################################################
+
+RUN wget https://github.com/github/hub/releases/download/v$HUB_VER/hub-$HUB_ARCH_TYPE-$HUB_VER.tgz \
+  && tar zvxvf hub-$HUB_ARCH_TYPE-$HUB_VER.tgz \
+  && ./hub-$HUB_ARCH_TYPE-$HUB_VER/install \
+  && rm -rf hub-$HUB_ARCH_TYPE-$HUB_VER
+
+###########################################################################
+# add user 'circleci':
+# cf. circleci/ruby:2.3.1-node
+# https://hub.docker.com/r/circleci/ruby/tags/
+###########################################################################
+
+RUN groupadd --gid 3434 circleci \
+  && useradd --uid 3434 --gid circleci --shell /bin/bash --create-home circleci \
+  && echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci \
+  && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
+
+USER circleci
+
+WORKDIR /target
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
## やったこと
ruby2.7.1のnode14.21.3のDockerfile作成

## 動作確認
- buildできた
```
docker build -t test:2 -f Dockerfile.node-14.21.3 .
[+] Building 324.9s (14/14) FINISHED 
```

- 指定のバージョンがインストールされている
```
 node -v
v14.21.3

yarn -v
1.22.4

ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
```

- ビルド& push
```
docker build --platform linux/amd64 -t fromscratch/ruby:2.7.1-node-14.21.3 -f Dockerfile.node-14.21.3 --push .
[+] Building 34.6s (15/15) FINISHED    
```

- pushできた
https://hub.docker.com/r/fromscratch/ruby/tags
![image](https://github.com/f-scratch/fs-dockerfiles/assets/124575694/0ec9b9e0-af71-46d6-9e9e-694f37a4fda0)
