### PR TITLE
[CHORE0981] add ruby/3.2.2 Node 22 image (Vite 移行用)

### DIFF
--- a/circleci/ruby/3.2.2/Dockerfile.node-22.9.0
+++ b/circleci/ruby/3.2.2/Dockerfile.node-22.9.0
@@ -1,0 +1,82 @@
+###########################################################################
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/ruby/tags/
+#
+# Note: Base Image name format fromscratch/ruby:{ruby-version}-node-{node-version}
+#       => fromscratch/ruby:3.2.2-node-22.9.0
+#
+# zelda-workflow4th の Vite 移行で Node 22 が必要なため追加。
+# 既存 Dockerfile.amazonlinux2 は amazonlinux2(glibc 2.26) のため Node 18+ の公式
+# prebuild(glibc 2.28+ 必須) が動かない。既存 node-14.21.3 と同様 Debian ベースの
+# 公式 ruby イメージを使い、Node は公式 node イメージ(同一 bookworm)から取り込む。
+#
+###########################################################################
+
+FROM ruby:3.2.2-bookworm
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# variables:
+###########################################################################
+
+ENV NODE_VERSION 22.9.0
+ENV YARN_VERSION 1.22.22
+ENV RUBYOPT=-EUTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+
+###########################################################################
+# node: 公式 node イメージ(同一 bookworm ベース)からコピー
+###########################################################################
+
+COPY --from=node:22.9.0-bookworm /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22.9.0-bookworm /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+  && ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack \
+  && node -v \
+  && npm -v
+
+###########################################################################
+# yarn: corepack で 1.x を有効化
+###########################################################################
+
+RUN corepack enable \
+  && corepack prepare yarn@${YARN_VERSION} --activate \
+  && yarn --version
+
+###########################################################################
+# native build deps / tools / awscli:
+#   amazonlinux2 版で入れていた mysql/pg/odbc 等の Debian 相当を揃える。
+#   shared-mime-info は mimemagic の native ext ビルドに必要。
+###########################################################################
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    git \
+    sudo \
+    tar \
+    bzip2 \
+    locales \
+    socat \
+    groff \
+    less \
+    default-libmysqlclient-dev \
+    default-mysql-client \
+    libpq-dev \
+    postgresql-client \
+    unixodbc-dev \
+    libyaml-dev \
+    shared-mime-info \
+    awscli \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /target
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## 概要 / Why

`zelda-workflow4th` のフロントエンドビルドを **Webpacker → Vite 5** へ移行するにあたり、CI で **Node 22** が必要になった（[zelda PR #957](https://github.com/f-scratch/zelda-workflow4th/pull/957) / issue #956）。現行の CI イメージ `fromscratch/ruby:3.2.2-amazonlinux2.0.20230822.0` は Node 12.18.0 で、`@rollup/plugin-yaml`(node>=14) 等の install に失敗する。

既存イメージは他リポでも使われているため**壊さず、Node 22 入りの variant を新規追加**する。

## 変更

- `circleci/ruby/3.2.2/Dockerfile.node-22.9.0` を追加
- **想定タグ: `fromscratch/ruby:3.2.2-node-22.9.0`**

## 設計判断

- **なぜ Debian ベース (`FROM ruby:3.2.2-bookworm`) か**: 既存 `amazonlinux2` 版は glibc 2.26。Node 18+ の公式 prebuild は **glibc 2.28+ が必須**で amazonlinux2 では動かない（ソースコンパイルは重く不安定）。既存 `circleci/ruby/2.7.1/Dockerfile.node-14.21.3` が既に `FROM ruby:X`(Debian) を採用しており、その前例に倣う。
- **Node は公式 `node:22.9.0-bookworm` から COPY**: 同一 bookworm ベースなので互換。古い `node-14.21.3` の GPG keyserver(`sks-keyservers.net` は2021年に廃止) 方式を避け、確実に取り込む。yarn は corepack で 1.22.22 を有効化。
- **native deps**: amazonlinux2 版で入れていた mysql/pg/odbc 相当を Debian パッケージで用意。`shared-mime-info` は `mimemagic` の native ext ビルドに必要（zelda の bundle install で実証済）。

## ⚠️ レビュー/マージ後に必要な作業（Docker Hub 権限が要る）

私（AI）では Docker のローカルビルド検証と Docker Hub への push ができないため、以下はインフラ担当での実施をお願いします:

1. `docker build -f circleci/ruby/3.2.2/Dockerfile.node-22.9.0 -t fromscratch/ruby:3.2.2-node-22.9.0 .` でビルド確認
2. zelda の CI 相当の確認（`yarn install` / `bundle install`(mysql2/pg/mimemagic の native ext) / `vite build` が通るか）
3. `docker push fromscratch/ruby:3.2.2-node-22.9.0`
4. その後 zelda 側 `.circleci/config.yml` の image を `fromscratch/ruby:3.2.2-node-22.9.0` に差し替え（zelda PR #957 側で対応）

### 検証時の確認ポイント（自信が低い箇所）
- bookworm のパッケージ名（`default-libmysqlclient-dev` / `libpq-dev` / `unixodbc-dev` / `awscli`）で mysql2・pg・odbc 系 gem がビルドできるか
- CI が root 実行前提（現行 amazonlinux2 版は root）。本イメージも root のままにしてある

🤖 Generated with [Claude Code](https://claude.com/claude-code)
