### PR TITLE
[IMP_BD100314] CircleCI用Ruby3.3.4イメージ(Amazon Linux 2023)のDockerfileを追加

### DIFF
--- a/circleci/ruby/3.3.4/Dockerfile.amazonlinux2023
+++ b/circleci/ruby/3.3.4/Dockerfile.amazonlinux2023
@@ -1,0 +1,105 @@
+###########################################################################
+#
+#--------------------------------------------------------------------------
+# Image Setup
+#--------------------------------------------------------------------------
+#
+# To change its version, see the available Tags on the Docker Hub:
+#    https://hub.docker.com/r/fromscratch/ruby/tags/
+#
+# Note: Base Image name format fromscratch/ruby:{ruby-version}-amazonlinux{amazonlinux-version}-{ami-version}
+#
+# NOTE: This image targets Amazon Linux 2023 (AL2023) to match the AL2023-based
+# EC2 AMIs used in darunia-terraformar (e.g. ec2_images.rails6_ruby3_3), so that
+# native gem / glibc issues surface in CI instead of only in production.
+# TODO: pin the exact amazonlinux:2023 tag before building/pushing this image
+# (left unpinned here since this file was authored without registry/build access).
+#
+###########################################################################
+
+FROM amazonlinux:2023
+
+LABEL maintainer "from scratch Co.Ltd."
+
+###########################################################################
+# Versions:
+###########################################################################
+
+ENV RUBY_MAJOR 3.3
+ENV RUBY_VERSION 3.3.4
+ENV NODE_VERSION 12.18.0
+ENV YARN_VERSION 1.22.5
+
+###########################################################################
+# Set Timezone
+###########################################################################
+
+ENV TZ Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+###########################################################################
+# Common:
+###########################################################################
+
+RUN echo "sslverify=false" >> /etc/dnf/dnf.conf
+# NOTE: AL2023 replaces libiodbc with unixODBC (see darunia-terraformar
+# roles/unixodbc-al2023 for the equivalent Ansible-side package swap).
+RUN dnf install -y git gcc gcc-c++ openssl openssl-devel readline readline-devel mysql mysql-devel bzip2 postgresql postgresql-devel sudo tar unixODBC unixODBC-devel libyaml libyaml-devel autoconf
+
+###########################################################################
+# Ruby:
+###########################################################################
+
+RUN mkdir -p /build/ruby
+RUN curl -k -o ruby.tar.gz https://cache.ruby-lang.org/pub/ruby/$RUBY_MAJOR/ruby-$RUBY_VERSION.tar.gz
+RUN tar -C /build/ruby -xzf ruby.tar.gz && rm ruby.tar.gz
+RUN cd /build/ruby/ruby-$RUBY_VERSION && \
+    ./configure --disable-install-doc && \
+    make && make install && \
+    gem install bundler && \
+    rm -fr /build/ruby
+
+###########################################################################
+# node:
+###########################################################################
+
+ENV NVM_DIR /root/.nvm
+
+RUN echo $HOME && \
+    curl -k -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash && \
+    . $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION} && \
+    nvm use ${NODE_VERSION} && \
+    nvm alias ${NODE_VERSION} && \
+    npm install eslint --save-dev && \
+    echo "" >> ~/.bashrc && \
+    echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.bashrc && \
+    echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.bashrc
+
+###########################################################################
+# YARN:
+###########################################################################
+
+RUN . $NVM_DIR/nvm.sh && nvm use ${NODE_VERSION} && npm install -g yarn
+
+ENV PATH /root/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH
+
+###########################################################################
+# awscli and socat:
+###########################################################################
+
+RUN dnf install -y python3 python3-devel
+RUN pip3 install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org --upgrade pip
+
+RUN pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org --upgrade setuptools && \
+    pip install --trusted-host pypi.org --trusted-host pypi.python.org --trusted-host=files.pythonhosted.org awscli
+
+###########################################################################
+# update sudoers
+###########################################################################
+
+RUN sed -i "/secure_path/c\Defaults    secure_path = $PATH" /etc/sudoers
+
+WORKDIR /target
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
[レビュー観点]( https://github.com/f-scratch/zelda-docs/blob/master/3.Rules/4.Review/3.SourceReview.md "レビュー観点")

## Redmineチケット

IMP_BD100314

## やったこと

`customerwatch4th-batch`（zelda-customerwatch4th）をAmazon Linux 2023へ移行するのに合わせて、アプリ側のRubyバージョンを3.2.2から3.3.4へ更新した（darunia-terraformar / zelda-customerwatch4th 側は別PRで対応済み）。

CircleCIのテスト実行イメージ `fromscratch/ruby:3.2.2-amazonlinux2.0.20230822.0` はまだRuby 3.2.2のままのため、`bundle install` 時に以下のエラーでCIが落ちている。

```
Your Ruby version is 3.2.2, but your Gemfile specified 3.3.4
```

これを解消するためのRuby 3.3.4イメージ用Dockerfileを追加した。

- `circleci/ruby/3.3.4/Dockerfile.amazonlinux2023` を新規作成
- 本番AMI側が今回Amazon Linux 2023へ移行するため、CIも同じくAL2023ベースにして環境差異（今回のRubyバージョン問題やnokogiriのglibc問題のような差異）をCI段階で検知できるようにした
- 既存の `3.2.2/Dockerfile.amazonlinux2` をベースに、AL2023向けの差分を反映
  - `yum` → `dnf`
  - `libiodbc` → `unixODBC`（darunia-terraformarの `roles/unixodbc-al2023` での対応と同様）

## やっていないこと（対応事項）

このPRは **Dockerfileの追加のみ** で、以下は未対応。マージ後、別途対応が必要です。

- [ ] このDockerfileを実際に `docker build` する
- [ ] ビルドしたイメージを Docker Hub (`fromscratch/ruby`) へ push する（対応者・実施者要確認。Docker Hub `fromscratch` organizationへのpush権限が必要）
- [ ] push後、`zelda-customerwatch4th` の `.circleci/config.yml` の `image: fromscratch/ruby:3.2.2-amazonlinux2.0.20230822.0` を新イメージのタグに更新する（該当PR: https://github.com/f-scratch/zelda-customerwatch4th/pull/1142 で追随予定）
- [ ] ビルド時に、mysql/mysql-devel・postgresql/postgresql-devel等のパッケージ名がAL2023のdnfリポジトリでも従来通り解決できるか未検証のため、ビルドログで要確認

上記が完了するまで `zelda-customerwatch4th` のCircleCIはRubyバージョン不一致で失敗し続けるため、優先度高めでの対応をお願いします。

## スクリーンショット

### before

（該当なし: Dockerfile追加のみのため）

### after

（該当なし: Dockerfile追加のみのため）

## 影響範囲調査結果

- 既存の `fromscratch/ruby:3.2.2-amazonlinux2...` 等、他バージョンのイメージ・利用先には影響しない（新規ディレクトリ追加のみ）
- 本Dockerfileが実際にビルド・push・CircleCI設定への反映までされない限り、既存のCI/デプロイフローへの影響はなし